### PR TITLE
#3 Added nn.socket() options table, including close_on_gc feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Installation
 ============
 
 Simply put [nanomsg-ffi.lua](https://github.com/neomantra/luajit-nanomsg/blob/master/nanomsg-ffi.lua)
-somewhere on your LUA_PATH and make sure that the [nanomsg](https://github.com/250bpm/nanomsg)
-shared library is available on your LD_LIBRARY_PATH.
+somewhere on your `LUA_PATH` and make sure that the [nanomsg](https://github.com/250bpm/nanomsg)
+shared library is available on your `LD_LIBRARY_PATH`.
 
 
 Usage
@@ -27,13 +27,13 @@ print( nn.C.nn_errno() )
 print( nn.errno() )
 print( nn.EAGAIN )
 
--- For convenience, names for errno's are abailable in nn.E
+-- For convenience, names for errno's are available in nn.E
 assert( nn.E[ nn.EAGAIN ] == 'EAGAIN' )
 
 -- Use the nn.socket class rather than the functions in nn.C
 local req, id, rc, err
 
-req, err = nn.socket( nn.AF_SP, nn.REQ )
+req, err = nn.socket( onn.REQ )
 assert( req, nn.strerror(err) )
 
 id, err = req:connect( "tcp://127.0.0.1:555" )
@@ -44,6 +44,20 @@ rc, err = req:send( msg, #msg )
 assert( rc > 0, nn.strerror(err) )
 
 ```
+
+Socket object
+=============
+
+Socket is nanomsg's primary object.  Socket object can instantiated with `nn.socket( protocol, options)`, where `protocol` is the nanomsg enum, such as `nn.SUB`, and `options` is a table with the following optional fields:
+
+ * `close_on_gc`:  Default is true.  When true, the socket's `close` method will be invoked upon garbage collection.  `close` may block, say one may to wish to invoke it manually at a determined time.
+
+ * `domain`:  Default is `nn.AF_SP`.  The domain of the socket.  Options are `nn.AF_SP` and `nn.AF_SP_RAW`.
+
+
+TODO: generate LDoc documentation and link to it
+
+
 
 Running the test suite
 ======================

--- a/examples/echo_client.lua
+++ b/examples/echo_client.lua
@@ -19,7 +19,7 @@ end
 
 print( '...client started...' )
 
-local req, err = nn.socket( nn.AF_SP, nn.REQ )
+local req, err = nn.socket( nn.REQ )
 assert( req, nn.strerror(err) )
 
 local eid, err = req:connect( ADDRESS )

--- a/examples/echo_server.lua
+++ b/examples/echo_server.lua
@@ -3,7 +3,7 @@ local nn = require 'nanomsg-ffi'
 
 local ADDRESS = "tcp://127.0.0.1:5556"
 
-local rep = nn.socket( nn.AF_SP, nn.REP )
+local rep = nn.socket( nn.REP )
 
 print("...starting server loop...")
 local echo

--- a/examples/pub_test.lua
+++ b/examples/pub_test.lua
@@ -12,7 +12,7 @@ end
 
 local channels = { arg[1], arg[2] }
 
-local pub, err = nn.socket( nn.AF_SP, nn.PUB )
+local pub, err = nn.socket( nn.PUB )
 assert( pub, nn.strerror(err) )
 
 local pid, err = pub:bind( ADDRESS )

--- a/examples/sub_test.lua
+++ b/examples/sub_test.lua
@@ -8,7 +8,7 @@ if #arg ~= 1 then
     os.exit(-1)
 end
 
-local sub, err = nn.socket( nn.AF_SP, nn.SUB )
+local sub, err = nn.socket( nn.SUB )
 assert( sub, nn.strerror(err) )
 
 local sid, err = sub:connect( ADDRESS )

--- a/nanomsg-ffi.test.lua
+++ b/nanomsg-ffi.test.lua
@@ -19,10 +19,10 @@ T:start("REQ/REP re-sending of request"); do
   -- from tests/reqrep.c
   local ADDRESS = "inproc://a"
   local rep, req, err
-  rep, err = nn.socket(nn.AF_SP, nn.REP)
+  rep, err = nn.socket(nn.REP)
   T:yes( rep )
   T:posint( rep:bind(ADDRESS) )
-  req, err = nn.socket(nn.AF_SP, nn.REQ)
+  req, err = nn.socket(nn.REQ)
   T:yes( req )
   T:posint( req:connect(ADDRESS) )
   local resend_ivl = ffi.new("int[1]", 100)
@@ -41,7 +41,7 @@ end; T:done()
 T:start("TCP close socket while not connected"); do
   -- from tests/tcp.c
   local ADDRESS = "tcp://127.0.0.1:5555"
-  local sc, err = nn.socket(nn.AF_SP, nn.PAIR)
+  local sc, err = nn.socket(nn.PAIR)
   T:yes( sc )
   T:posint( sc:connect(ADDRESS) )
   T:eq( sc:close(sc), 0 )
@@ -51,10 +51,10 @@ T:start("TCP PAIR ping-pong"); do
   -- from tests/tcp.c
   local ADDRESS = "tcp://127.0.0.1:5555"
   local sc, sb, err
-  sc, err = nn.socket(nn.AF_SP, nn.PAIR)
+  sc, err = nn.socket(nn.PAIR)
   T:yes( sc )
   T:posint( sc:connect(ADDRESS) )
-  sb, err = nn.socket(nn.AF_SP, nn.PAIR)
+  sb, err = nn.socket(nn.PAIR)
   T:yes( sb )
   T:posint( sb:bind(ADDRESS) )
   local buf = ffi.new("char[32]")
@@ -72,10 +72,10 @@ T:start("TCP PAIR batch transfer"); do
   -- from tests/tcp.c
   local ADDRESS = "tcp://127.0.0.1:5555"
   local sc, sb, err
-  sc, err = nn.socket(nn.AF_SP, nn.PAIR)
+  sc, err = nn.socket(nn.PAIR)
   T:yes( sc )
   T:posint( sc:connect(ADDRESS) )
-  sb, err = nn.socket(nn.AF_SP, nn.PAIR)
+  sb, err = nn.socket(nn.PAIR)
   T:yes( sb )
   T:posint( sb:bind(ADDRESS) )
   local buf = ffi.new("char[32]")
@@ -92,10 +92,10 @@ T:start("TCP REQ/REP socket reuse"); do
   local req_buf, rep_buf = ffi.new("char[32]"), ffi.new("char[32]")
   local req, rep, err
   for i=1,10 do
-    rep, err = nn.socket(nn.AF_SP, nn.REP)
+    rep, err = nn.socket(nn.REP)
     T:yes( rep )
     T:posint( rep:bind(ADDRESS) )
-    req, err = nn.socket(nn.AF_SP, nn.REQ)
+    req, err = nn.socket(nn.REQ)
     T:yes( req )
     T:posint( req:connect(ADDRESS) )
     T:eq( req:send("REQ", 3, 0), 3 )


### PR DESCRIPTION
This replaces the other nn_close branch, using an option table instead.   I folded the domain into the option table since AF_SP will be the most common option.  
